### PR TITLE
Add tests option to Cli arguments

### DIFF
--- a/calico/base.py
+++ b/calico/base.py
@@ -233,7 +233,7 @@ class Calico(OrderedDict):
         super().__setitem__(case.name, case)
         self.points += case.points if case.points is not None else 0
 
-    def run(self, *, quiet=False):
+    def run(self, *, tests=None, quiet=False):
         """Run this test suite.
 
         :sig: (Optional[bool]) -> Mapping[str, Any]
@@ -244,9 +244,9 @@ class Calico(OrderedDict):
         earned_points = 0
 
         os.environ["TERM"] = "dumb"  # disable color output in terminal
-
+        tests = [] if tests is None else tests
         for test_name, test in self.items():
-            if test_name[0] == "_":
+            if test_name[0] == "_" or (test_name.startswith("case") and test_name not in tests):
                 continue
 
             _logger.debug("starting test %s", test_name)

--- a/calico/cli.py
+++ b/calico/cli.py
@@ -46,6 +46,7 @@ def make_parser(prog):
     parser.add_argument("-q", "--quiet", action="store_true", help="disable most messages")
     parser.add_argument("--log", action="store_true", help="log messages to file")
     parser.add_argument("--debug", action="store_true", help="enable debug messages")
+    parser.add_argument("-t", "--tests", nargs="*", help="specify which tests cases will run")
     return parser
 
 
@@ -96,7 +97,7 @@ def main(argv=None):
         runner = parse_spec(content)
 
         if not arguments.validate:
-            report = runner.run(quiet=arguments.quiet)
+            report = runner.run(tests=arguments.tests, quiet=arguments.quiet)
             score = report["points"]
             print(f"Grade: {score} / {runner.points}")
     except Exception as e:


### PR DESCRIPTION
With this option, debugging specific test cases will be easier. Firstly, I decided to expand `--debug` option  with case names like `calico --debug case_0 case_1`. However, later I've found it more appropriate to create a new option.