### PR TITLE
Support "return" keyword to be used to specify exit status

### DIFF
--- a/calico/parse.py
+++ b/calico/parse.py
@@ -57,8 +57,7 @@ def get_attribute(node, test_name, names, val_func, val_args, err_message):
     :param val_args: An argument to the validator function
     :param err_message: An error message to shown when validation fails
     """
-    _short, _long = names
-    attr = node.get(_long, node.get(_short))
+    attr = next(filter(lambda i: i is not None, map(node.get, names)), None)
     if attr is not None:
         if val_args is None:
             result = val_func(attr)
@@ -124,7 +123,7 @@ def parse_spec(content):
         (
             "exits",
             {
-                "names": ("x", "exit"),
+                "names": ("x", "exit", "return"),
                 "val_func": isinstance,
                 "val_args": int,
                 "err_message": "%s: Exit status value must be an integer",

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -328,9 +328,14 @@ prompts- you can define variables in the special ``_define`` section:
 
 .. note::
 
+   Although not mentioned in the tutorial, you can also use the ``return``
+   keyword instead of ``exit``.
+
+.. note::
+
    To make the specification file shorter, you can use the following
    shortcuts for the keywords: ``r`` for ``run``, ``e`` for ``expect``,
-   ``s`` for ``send``, ``x`` for ``exit``, ``b`` for ``blocker``,
+   ``s`` for ``send``, ``x`` for ``exit`` or ``return``, ``b`` for ``blocker``,
    ``v`` for ``visible``, ``p`` for ``points``.
 
 Jailing tests

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -79,6 +79,16 @@ def test_case_default_exit_status_should_be_zerd():
     assert runner["c1"].exits == 0
 
 
+def test_case_return_keyword_should_be_ok_for_exit_status():
+    source = """
+          - c1:
+              run: "false"
+              return: 1
+        """
+    runner = parse_spec(source)
+    assert runner["c1"].exits == 1
+
+
 def test_case_integer_exit_status_should_be_ok():
     source = """
       - c1:


### PR DESCRIPTION
I recently realized that *calico* doesn't use `return` keyword to specify exit status of the program. <s>The keyword was `exit` since the beginning and it has never changed</s> The keyword was changed to `exit` in [this commit](https://github.com/itublg/calico/commit/48cfc069964c39dec43659b9a42f7dcab83232aa) but [the testers](https://github.com/Asocia/schoolwork/blob/master/2018/BLG%20252E%20Object%20Oriented%20Programming/assignment-2/official_tests/BLG252E_OOP19_HW2_Evaluation_Tests.t) [keep](https://github.com/Asocia/schoolwork/blob/master/2018/BLG%20223E%20Data%20Structures/assignment-4/tests/Data_Structures_HW4_Evaluation_Tests.t) [using](https://github.com/Asocia/schoolwork/blob/master/2018/BLG%20223E%20Data%20Structures/assignment-5/tests/official_tests/hw5.t) `return` <s>for some reason</s>(the reason is obvious actually). Including myself, the testers were unaware that `return: 0` actually does nothing because it is ignored by *calico* and the exit status of test case defaults to `0` when `exit` keyword is not present. Moreover, they avoid writing programs which returns 1 because when they try to test it, they were seeing `exit status: 1 (expected 0)` even though they write `return: 1` in the test specification.

I don't know if ignoring unknown keywords silently has some purpose so I didn't want to touch that part. Instead, I modified related parts of code to support `return` keyword so that it can be used as intended. 

I run the tests with Python3.8 and only the ones that are related with system calico have been failed because I don't have calico installed.
<pre>
============================================================================================ short test summary info =============================================================================================
FAILED tests/test_calico.py::test_installed_version_should_match_package_version - pkg_resources.DistributionNotFound: The 'calico' distribution was not found and is required by the application
FAILED tests/test_cli.py::test_cli_version_should_print_version_number_and_exit - pkg_resources.DistributionNotFound: The 'calico' distribution was not found and is required by the application
========================================================================================== 2 failed, 62 passed in 5.03s ==========================================================================================
<pre>
