### PR TITLE
replace YAML.round_trip_load_all() with YAML.load()

### DIFF
--- a/calico/parse.py
+++ b/calico/parse.py
@@ -18,7 +18,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from ruamel import yaml
-from ruamel.yaml import comments
+from ruamel.yaml import comments, YAML
 
 from .base import Action, ActionType, Calico, TestCase
 
@@ -77,7 +77,7 @@ def parse_spec(content):
     :raise AssertionError: When given specification is invalid.
     """
     try:
-        spec = yaml.round_trip_load(content)
+        spec = YAML(typ='safe').load(content)
     except yaml.YAMLError as e:
         raise AssertionError(str(e))
 


### PR DESCRIPTION
Calico uses YAML.round_trip_load_all() to load the content but it is deprecated

parse.py, line: 79-82
```python
try:
    spec = yaml.round_trip_load(content)
except yaml.YAMLError as e:
    raise AssertionError(str(e))
```

Official documentation suggest using YAML.load() to load the document
```python
from ruamel.yaml import YAML

yaml=YAML(typ='safe')   # default, if not specified, is 'rt' (round-trip)
yaml.load(doc)
```